### PR TITLE
Match existing icpdata_addon_version for manual deployment

### DIFF
--- a/doc/src/pages/monitors/cp4d-cognos-connections-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-cognos-connections-info/manual/index.mdx
@@ -59,6 +59,7 @@ oc label sts c-db2oltp-${DB2_INSTANCE_ID}-db2u cognos_instance_id=${COGNOS_INSTA
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -69,7 +70,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-cognos-task-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-cognos-task-info/manual/index.mdx
@@ -59,6 +59,7 @@ oc label sts c-db2oltp-${DB2_INSTANCE_ID}-db2u cognos_instance_id=${COGNOS_INSTA
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -69,7 +70,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-platform-global-connections/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-platform-global-connections/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -56,7 +57,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-watsonstudio-job-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-watsonstudio-job-info/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -56,7 +57,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-watsonstudio-job-schedule-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-watsonstudio-job-schedule-info/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -56,7 +57,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-watsonstudio-runtime-usage/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-watsonstudio-runtime-usage/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -55,7 +56,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-wkc-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-wkc-info/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -55,7 +56,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-wml-deployment-space-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-wml-deployment-space-info/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -55,7 +56,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |

--- a/doc/src/pages/monitors/cp4d-wml-deployment-space-job-info/manual/index.mdx
+++ b/doc/src/pages/monitors/cp4d-wml-deployment-space-job-info/manual/index.mdx
@@ -46,6 +46,7 @@ Ensure the build finishes with the message `Push successful`
 ```
 export CP4D_PROJECT=<CP4D_PROJECT>
 export OPENSHIFT_IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/${CP4D_PROJECT}
+export ICPDATA_ADDON_VERSION=$(oc get po -l component=zen-watcher -o jsonpath='{.items[0].metadata.annotations.productVersion}')
 
 cat << EOF | oc apply -f -
 kind: ConfigMap
@@ -55,7 +56,7 @@ metadata:
   labels:
     app: zen-adv
     icpdata_addon: 'true'
-    icpdata_addon_version: 4.3.0
+    icpdata_addon_version: ${ICPDATA_ADDON_VERSION}
     release: zen-adv
 data:
   extensions: |


### PR DESCRIPTION
Hello @arthurlaimbock,

I've tested these monitors a few times and previously provided suggestions for improvement, but this time I'm contributing myself. I hope the help is appreciated!

In my recent testing, the manual deployment guide currently provides a ConfigMap did not work for my version of CP4D due to a version mismatch with the annotation mentioned in the title. This is a simple improvement to the docs to help other users quickly deploy with one less error to debug.

Thanks!